### PR TITLE
add functions to make and remove vsi dirs

### DIFF
--- a/examples/vsi/vsi.go
+++ b/examples/vsi/vsi.go
@@ -8,30 +8,59 @@ import (
 )
 
 func main() {
+
+	err := gdal.VSIMkdir("/vsimem/a_dir")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	dir := "/vsimem/a_directory/asdf"
+	err = gdal.VSIMkdirRecursive(dir)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	driver, err := gdal.GetDriverByName("GTiff")
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	ds := driver.Create("/vsimem/tmp.tif", 256, 256, 1, gdal.Byte, []string{})
+	ds := driver.Create("/vsimem/a_directory/tmp.tif", 256, 256, 1, gdal.Byte, []string{})
 	ds.Close()
 
 	fmt.Println("Globbing all vsimem files:")
-	fmt.Println(gdal.VSIReadDirRecursive("/vsimem/"))
+	fmt.Println(gdal.VSIReadDirRecursive("/vsimem/"), "\n")
+
+	err = gdal.VSIRmdir("/vsimem/a_dir")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("Globbing all vsimem files after rmdir:")
+	fmt.Println(gdal.VSIReadDirRecursive("/vsimem/"), "\n")
 
 	fmt.Println("Adding a second vsimem file...")
-	ds2 := driver.Create("/vsimem/tmp2.tif", 256, 256, 1, gdal.Byte, []string{})
+	ds2 := driver.Create("/vsimem/a_directory/tmp2.tif", 256, 256, 1, gdal.Byte, []string{})
 	ds2.Close()
+
+	fmt.Println("Globbing vsimem files in a_directory/:")
+	fmt.Println(gdal.VSIReadDirRecursive("/vsimem/a_directory"), "\n")
+
+	err = gdal.VSIMkdir("/vsimem/a_dir2")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("Globbing all vsimem files:")
+	fmt.Println(gdal.VSIReadDirRecursive("/vsimem/"), "\n")
+
+	fmt.Println("Removing a_directory/*:")
+	err = gdal.VSIRmdirRecursive("/vsimem/a_directory")
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	fmt.Println("Globbing all vsimem files:")
 	fmt.Println(gdal.VSIReadDirRecursive("/vsimem/"))
 
-	fmt.Println("Unlinking the first vsimem file...")
-	err = gdal.VSIUnlink("/vsimem/tmp.tif")
-	if err != nil {
-		fmt.Println(err)
-	}
-
-	fmt.Println("Globbing all vsimem files again:")
-	fmt.Println(gdal.VSIReadDirRecursive("/vsimem/"))
 }

--- a/gdal.go
+++ b/gdal.go
@@ -1848,13 +1848,65 @@ func VSIFReadL(nSize, nCount int, file VSILFILE) []byte {
 	return data
 }
 
-// Delete a file. This method goes through the VSIFileHandler virtualization and may work on unusual filesystems such as in memory.
+// Delete a file. This method goes through the VSIFileHandler virtualization and may work on
+// unusual filesystems such as in memory.
 func VSIUnlink(fileName string) error {
 	cFileName := C.CString(fileName)
 	defer C.free(unsafe.Pointer(cFileName))
 	deleted := C.VSIUnlink(cFileName)
 	if deleted != 0 {
 		return fmt.Errorf("Error: VSILFILE '%s' unlink error", fileName)
+	}
+	return nil
+}
+
+// Create a new directory with the indicated mode.
+// The mode is ignored on some platforms.
+// A reasonable default mode value would be 0666.
+// This method goes through the VSIFileHandler virtualization
+// and may work on unusual filesystems such as in memory.
+func VSIMkdir(dir string) error {
+	cDir := C.CString(dir)
+	defer C.free(unsafe.Pointer(cDir))
+	made := C.VSIMkdir(cDir, C.long(uint32(0666)))
+	if int(made) != 0 {
+		return fmt.Errorf("Error: VSILFILE '%s' mkdir error", dir)
+	}
+	return nil
+}
+
+// Create a directory and all its ancestors.
+func VSIMkdirRecursive(dir string) error {
+	cDir := C.CString(dir)
+	defer C.free(unsafe.Pointer(cDir))
+	made := C.VSIMkdirRecursive(cDir, C.long(uint32(0666)))
+	if int(made) != 0 {
+		return fmt.Errorf("Error: VSILFILE '%s' mkdir resursive error", dir)
+	}
+	return nil
+}
+
+// Deletes a directory object from the file system. On some systems the directory must be empty before it can be deleted.
+// This method goes through the VSIFileHandler virtualization and may work on unusual filesystems such as in memory.
+func VSIRmdir(dir string) error {
+	cDir := C.CString(dir)
+	defer C.free(unsafe.Pointer(cDir))
+	deleted := C.VSIRmdir(cDir)
+	if deleted != 0 {
+		return fmt.Errorf("Error: VSILFILE '%s' unlink error", dir)
+	}
+	return nil
+}
+
+// Delete a directory recursively.
+// Deletes a directory object and its content from the file system.
+// Starting with GDAL 3.1, /vsis3/ has an efficient implementation of this function.
+func VSIRmdirRecursive(dir string) error {
+	cDir := C.CString(dir)
+	defer C.free(unsafe.Pointer(cDir))
+	deleted := C.VSIRmdirRecursive(cDir)
+	if deleted != 0 {
+		return fmt.Errorf("Error: VSILFILE '%s' unlink error", dir)
 	}
 	return nil
 }


### PR DESCRIPTION
Add functions to make and remove directiories in the vsi file system.

Functions include:

- [VSIMkdir](https://gdal.org/api/cpl.html#_CPPv48VSIMkdirPKcl)
- [VSIMkdirRecursive](https://gdal.org/api/cpl.html#_CPPv417VSIMkdirRecursivePKcl)
- [VSIRmdir](https://gdal.org/api/cpl.html#_CPPv48VSIRmdirPKc)
- [VSIRmdirRecursive](https://gdal.org/api/cpl.html#_CPPv417VSIRmdirRecursivePKc)

I also drafted a release that can be cut when this is reviewed and pulled into master.