### PR TITLE
add concave hull function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/dewberry/gdal
 
-go 1.14
+go 1.19

--- a/ogr.go
+++ b/ogr.go
@@ -522,7 +522,7 @@ func (geom Geometry) ConvexHull() Geometry {
 
 // Compute concave hull for the geometry
 func (geom Geometry) ConcaveHull(dfRatio float64, bAllowHoles bool) Geometry {
-	newGeom := C.OGR_G_ConcaveHull(geom.cval, C.double(dfRatio), bAllowHoles)
+	newGeom := C.OGR_G_ConcaveHull(geom.cval, C.double(dfRatio), C.bool(bAllowHoles))
 	return Geometry{newGeom}
 }
 

--- a/ogr.go
+++ b/ogr.go
@@ -520,9 +520,9 @@ func (geom Geometry) ConvexHull() Geometry {
 	return Geometry{newGeom}
 }
 
-// Compute convex hull for the geometry
-func (geom Geometry) ConcaveHull() Geometry {
-	newGeom := C.OGR_G_ConcaveHull(geom.cval)
+// Compute concave hull for the geometry
+func (geom Geometry) ConcaveHull(dfRatio float64, bAllowHoles bool) Geometry {
+	newGeom := C.OGR_G_ConcaveHull(geom.cval, C.double(dfRatio), bAllowHoles)
 	return Geometry{newGeom}
 }
 

--- a/ogr.go
+++ b/ogr.go
@@ -188,7 +188,7 @@ type Geometry struct {
 	cval C.OGRGeometryH
 }
 
-//Create a geometry object from its well known binary representation
+// Create a geometry object from its well known binary representation
 func CreateFromWKB(wkb []uint8, srs SpatialReference, bytes int) (Geometry, error) {
 	cString := unsafe.Pointer(&wkb[0])
 	var newGeom Geometry
@@ -197,7 +197,7 @@ func CreateFromWKB(wkb []uint8, srs SpatialReference, bytes int) (Geometry, erro
 	).Err()
 }
 
-//Create a geometry object from its well known text representation
+// Create a geometry object from its well known text representation
 func CreateFromWKT(wkt string, srs SpatialReference) (Geometry, error) {
 	cString := C.CString(wkt)
 	defer C.free(unsafe.Pointer(cString))
@@ -207,7 +207,7 @@ func CreateFromWKT(wkt string, srs SpatialReference) (Geometry, error) {
 	).Err()
 }
 
-//Create a geometry object from its GeoJSON representation
+// Create a geometry object from its GeoJSON representation
 func CreateFromJson(_json string) Geometry {
 	cString := C.CString(_json)
 	defer C.free(unsafe.Pointer(cString))
@@ -517,6 +517,12 @@ func (geom Geometry) Boundary() Geometry {
 // Compute convex hull for the geometry
 func (geom Geometry) ConvexHull() Geometry {
 	newGeom := C.OGR_G_ConvexHull(geom.cval)
+	return Geometry{newGeom}
+}
+
+// Compute convex hull for the geometry
+func (geom Geometry) ConcaveHull() Geometry {
+	newGeom := C.OGR_G_ConcaveHull(geom.cval)
 	return Geometry{newGeom}
 }
 


### PR DESCRIPTION
Upgrades: Version og Gdal to 3.6 and Golang to 1.20
Adds: ConcaveHull() method